### PR TITLE
Revert "Removed extra pear channels"

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -1,8 +1,5 @@
-# 
 # Author:: Mark Sonnabaum <mark.sonnabaum@acquia.com>
-# Contributor:: Patrick Connolly <patrick@myplanetdigital.com>
-#
-# Cookbook Name:: phpunit
+# Cookbook Name::  phpunit
 # Recipe:: default
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,8 +16,11 @@
 
 include_recipe "php"
 
-php_pear_channel "pear.phpunit.de" do
-  action [:discover, :update]
+channels = %w{pear.phpunit.de components.ez.no pear.symfony-project.com}
+channels.each do |chan|
+  php_pear_channel chan do
+    action [:discover, :update]
+  end
 end
 
 php_pear "PEAR" do
@@ -35,3 +35,4 @@ php_pear "PHPUnit" do
   version "3.6.7"
   action :install
 end
+


### PR DESCRIPTION
This reverts commit d78ca833eac74b1d065a83a446ca3d8b8b722b50 from pull request #6.

That commit removed some extra pear channels from the discovery list.  However, on a bare bones installation of php+pear, those channels are needed to install PHPUnit's dependencies.  This cookbook did not work for me without them.
