### PR TITLE
Update symfony PEAR channel

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -20,7 +20,7 @@
 include_recipe "php"
 
 # phpunit/PHPUnit depends on symfony/YAML
-channels = %w{pear.phpunit.de pear.symfony-project.com}
+channels = %w{pear.phpunit.de pear.symfony.com}
 channels.each do |chan|
   php_pear_channel chan do
     action [:discover, :update]


### PR DESCRIPTION
Fabien [announced recently](http://symfony.com/blog/symfony-1-x-documentation) that the Symfony 1 branch is approaching end of maintenance, and such, the original domain www.symfony-project.org is being phased out. The old PEAR channel was previously hosted at http://pear.symfony-project.com

If using this recipe and try installing newest PHPUnit (3.7.8 at time of writing) it will error because YAML 2.\* component is not registered on pear.symfony-project.com

The new http://pear.symfony.com has all newest Symfony packages.
